### PR TITLE
feat(cli): auto-load .env file for credentials

### DIFF
--- a/src/ticktick_sdk/cli.py
+++ b/src/ticktick_sdk/cli.py
@@ -32,7 +32,26 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+
+def load_dotenv_if_available() -> None:
+    """Load .env file if python-dotenv is available."""
+    try:
+        from dotenv import load_dotenv
+
+        # Try current directory first, then walk up to find .env
+        cwd = Path.cwd()
+        for parent in [cwd, *cwd.parents]:
+            env_file = parent / ".env"
+            if env_file.exists():
+                load_dotenv(env_file)
+                return
+        # Fallback: let dotenv search for .env
+        load_dotenv()
+    except ImportError:
+        pass  # python-dotenv not installed, skip
 
 
 def get_version() -> str:
@@ -199,6 +218,9 @@ def main() -> int | NoReturn:
     Returns:
         Exit code (0 for success, non-zero for error).
     """
+    # Load .env file before doing anything else
+    load_dotenv_if_available()
+
     parser = create_parser()
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

The CLI now automatically loads a `.env` file (if `python-dotenv` is available) before processing commands.

## Problem

The README instructs users to create a `.env` file with credentials, but the CLI didn't actually load it. Users had to manually `export` the variables or source the file, which was confusing.

## Solution

Added a `load_dotenv_if_available()` function that:
- Checks if `python-dotenv` is installed (it's already a dev dependency)
- Searches the current directory and parent directories for `.env`
- Loads the first `.env` file found

This matches the common convention and makes `ticktick-sdk auth` work out of the box after creating a `.env` file.

## Testing

1. Create a `.env` file with `TICKTICK_CLIENT_ID` and `TICKTICK_CLIENT_SECRET`
2. Run `ticktick-sdk auth`
3. Credentials are now picked up automatically ✓