### PR TITLE
docs: add Codex CLI instructions and clarify .env auto-loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,16 @@ Use TickTick with AI assistants like Claude through the Model Context Protocol.
 
 ### Step 2: Get OAuth2 Access Token
 
-Run the auth command with your credentials:
+Create a `.env` file with your credentials (the CLI loads it automatically):
 
 ```bash
-TICKTICK_CLIENT_ID=your_client_id \
-TICKTICK_CLIENT_SECRET=your_client_secret \
+TICKTICK_CLIENT_ID=your_client_id
+TICKTICK_CLIENT_SECRET=your_client_secret
+```
+
+Then run:
+
+```bash
 ticktick-sdk auth
 ```
 
@@ -210,6 +215,25 @@ Add to your Claude Desktop config:
     }
   }
 }
+```
+
+#### Codex CLI
+
+```bash
+codex mcp add ticktick \
+  --env TICKTICK_CLIENT_ID=your_client_id \
+  --env TICKTICK_CLIENT_SECRET=your_client_secret \
+  --env TICKTICK_ACCESS_TOKEN=your_access_token \
+  --env TICKTICK_USERNAME=your_email \
+  --env TICKTICK_PASSWORD=your_password \
+  -- ticktick-sdk
+```
+
+Verify it's working:
+
+```bash
+codex mcp list         # See configured servers
+codex                  # Start Codex - TickTick tools are now available
 ```
 
 #### Other MCP-Compatible Tools


### PR DESCRIPTION
## Summary

Documentation updates following the merged `.env` auto-loading feature.

## Changes

### 1. Updated Step 2 (Get OAuth2 Access Token)

Now shows the recommended approach of creating a `.env` file:

```bash
TICKTICK_CLIENT_ID=your_client_id
TICKTICK_CLIENT_SECRET=your_client_secret
```

Then simply running `ticktick-sdk auth` - the CLI now auto-loads the `.env` file.

### 2. Added Codex CLI Instructions

Added configuration instructions for [OpenAI Codex CLI](https://github.com/openai/codex), which also supports MCP servers:

```bash
codex mcp add ticktick \
  --env TICKTICK_CLIENT_ID=your_client_id \
  ...
  -- ticktick-sdk
```

This sits alongside the existing Claude Code and Claude Desktop instructions.

## Why

- The `.env` approach is cleaner than inline environment variables
- Codex CLI is gaining popularity and has full MCP support
- Both changes make the SDK more accessible to users