### PR TITLE
fix: handle string and empty repeatFrom values from API

### DIFF
--- a/src/ticktick_sdk/models/task.py
+++ b/src/ticktick_sdk/models/task.py
@@ -185,6 +185,17 @@ class Task(TickTickModel):
             ]
         return []
 
+    @field_validator("repeat_from", mode="before")
+    @classmethod
+    def parse_repeat_from(cls, v: Any) -> int | None:
+        if v is None or v == "":
+            return None
+        if isinstance(v, int):
+            return v
+        if isinstance(v, str):
+            return int(v)
+        return None
+
     # Properties
     @property
     def is_completed(self) -> bool:


### PR DESCRIPTION
## Summary
- Added field validator to parse `repeatFrom` field correctly
- Handles string values (`"0"`, `"1"`, `"2"`), `null`, and empty string `""`
- The TickTick API returns `repeatFrom` as a string, but the model expected `int | None`

Fixes #7

## Test plan
- [x] Tested with `ticktick_list_tasks` - tasks with recurring schedules now parse correctly