### PR TITLE
feat: Add abandon_task (Won't Do) action

### DIFF
--- a/src/ticktick_sdk/client/client.py
+++ b/src/ticktick_sdk/client/client.py
@@ -284,6 +284,19 @@ class TickTickClient:
         """
         await self._api.complete_task(task_id, project_id)
 
+    async def abandon_task(self, task_id: str, project_id: str) -> None:
+        """
+        Mark a task as abandoned ("Won't do").
+
+        This is a V2-only operation. Abandoned tasks appear in the
+        "Abandoned" section of completed tasks in TickTick.
+
+        Args:
+            task_id: Task ID
+            project_id: Project ID
+        """
+        await self._api.abandon_task(task_id, project_id)
+
     async def delete_task(self, task_id: str, project_id: str) -> None:
         """
         Delete a task.
@@ -651,6 +664,24 @@ class TickTickClient:
             Batch response with id2etag and id2error
         """
         return await self._api.batch_complete_tasks(task_ids)
+
+    async def abandon_tasks(
+        self,
+        task_ids: list[tuple[str, str]],
+    ) -> dict[str, Any]:
+        """
+        Abandon ("Won't do") one or more tasks.
+
+        This is a V2-only operation. Abandoned tasks appear in the
+        "Abandoned" section of completed tasks in TickTick.
+
+        Args:
+            task_ids: List of (task_id, project_id) tuples
+
+        Returns:
+            Batch response with id2etag and id2error
+        """
+        return await self._api.batch_abandon_tasks(task_ids)
 
     async def move_tasks(
         self,

--- a/src/ticktick_sdk/server.py
+++ b/src/ticktick_sdk/server.py
@@ -847,6 +847,63 @@ async def ticktick_complete_tasks(params: CompleteTasksInput, ctx: Context) -> s
 
 
 @mcp.tool(
+    name="ticktick_abandon_tasks",
+    annotations={
+        "title": "Abandon Tasks (Won't Do)",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def ticktick_abandon_tasks(params: CompleteTasksInput, ctx: Context) -> str:
+    """
+    Mark one or more tasks as abandoned ("Won't do").
+
+    Changes task status to abandoned (-1). Abandoned tasks appear in the
+    "Abandoned" section of completed tasks in TickTick, separate from
+    completed tasks. Use this when a task is no longer relevant or will
+    not be done, but you want to keep a record of it.
+
+    Supports batch operations (1-100 tasks).
+
+    Args:
+        params: Abandon parameters:
+            - tasks (list, required): List of task identifiers (1-100 tasks)
+              Each task must contain:
+                - task_id (str): Task to abandon
+                - project_id (str): Project containing the task
+            - response_format (str): 'markdown' (default) or 'json'
+
+    Returns:
+        Success confirmation or error message.
+
+    Examples:
+        Single task:
+            tasks=[{"task_id": "abc123", "project_id": "proj1"}]
+
+        Multiple tasks:
+            tasks=[
+                {"task_id": "abc1", "project_id": "proj1"},
+                {"task_id": "abc2", "project_id": "proj1"}
+            ]
+    """
+    try:
+        client = get_client(ctx)
+        task_ids = [(t.task_id, t.project_id) for t in params.tasks]
+        await client.abandon_tasks(task_ids)
+
+        count = len(task_ids)
+        if count == 1:
+            return success_message(f"Task `{task_ids[0][0]}` marked as abandoned (won't do).")
+        else:
+            return success_message(f"{count} tasks marked as abandoned (won't do).")
+
+    except Exception as e:
+        return handle_error(e, "abandon_tasks")
+
+
+@mcp.tool(
     name="ticktick_delete_tasks",
     annotations={
         "title": "Delete Tasks",

--- a/src/ticktick_sdk/unified/api.py
+++ b/src/ticktick_sdk/unified/api.py
@@ -654,6 +654,46 @@ class UnifiedTickTickAPI:
             operation="complete_task",
         )
 
+    async def abandon_task(self, task_id: str, project_id: str) -> None:
+        """
+        Mark a task as abandoned ("Won't do").
+
+        Uses V2 API only (abandoned status is V2-only).
+
+        Note: V2 batch operations silently accept updates to nonexistent tasks,
+        so we verify the task exists first to provide proper error handling.
+
+        Args:
+            task_id: Task ID
+            project_id: Project ID
+
+        Raises:
+            TickTickNotFoundError: If the task does not exist
+            TickTickAPIUnavailableError: If V2 API is not available
+        """
+        self._ensure_initialized()
+
+        if not self._router.has_v2:
+            raise TickTickAPIUnavailableError(
+                "Abandon task requires V2 API (abandoned status is V2-only)",
+                operation="abandon_task",
+            )
+
+        # V2 batch API silently accepts updates to nonexistent tasks (returns
+        # empty etag but no error). Verify task exists first for proper errors.
+        await self._v2_client.get_task(task_id)  # type: ignore  # Raises NotFoundError if missing
+
+        response = await self._v2_client.batch_tasks(  # type: ignore
+            update=[{
+                "id": task_id,
+                "projectId": project_id,
+                "status": TaskStatus.ABANDONED,
+                "completedTime": Task.format_datetime(datetime.now(), "v2"),
+            }]
+        )
+        # Check for errors in batch response (shouldn't happen after verify)
+        _check_batch_response_errors(response, "abandon_task", [task_id])
+
     async def delete_task(self, task_id: str, project_id: str) -> None:
         """
         Delete a task.
@@ -1194,6 +1234,43 @@ class UnifiedTickTickAPI:
 
         response = await self._v2_client.batch_tasks(update=updates)  # type: ignore
         _check_batch_response_errors(response, "batch_complete_tasks", [tid for tid, _ in task_ids])
+        return response
+
+    async def batch_abandon_tasks(
+        self,
+        task_ids: list[tuple[str, str]],
+    ) -> dict[str, Any]:
+        """
+        Abandon ("Won't do") multiple tasks in a batch operation.
+
+        V2-only operation.
+
+        Args:
+            task_ids: List of (task_id, project_id) tuples
+
+        Returns:
+            Batch response with id2etag and id2error
+
+        Raises:
+            TickTickAPIUnavailableError: If V2 API is not available
+        """
+        self._ensure_initialized()
+
+        if not self._router.has_v2:
+            raise TickTickAPIUnavailableError(
+                "V2 API is required for batch_abandon_tasks",
+                operation="batch_abandon_tasks",
+            )
+
+        updates = [{
+            "id": tid,
+            "projectId": pid,
+            "status": TaskStatus.ABANDONED,
+            "completedTime": Task.format_datetime(datetime.now(), "v2"),
+        } for tid, pid in task_ids]
+
+        response = await self._v2_client.batch_tasks(update=updates)  # type: ignore
+        _check_batch_response_errors(response, "batch_abandon_tasks", [tid for tid, _ in task_ids])
         return response
 
     async def batch_move_tasks(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -687,6 +687,19 @@ class MockUnifiedAPI:
         task.status = TaskStatus.COMPLETED
         task.completed_time = utc_now()
 
+    async def abandon_task(self, task_id: str, project_id: str) -> None:
+        """Mock abandon task (set to 'Won't do' status)."""
+        self._record_call("abandon_task", (task_id, project_id), {})
+        self._check_failure("abandon_task")
+
+        if task_id not in self.tasks:
+            from ticktick_sdk.exceptions import TickTickNotFoundError
+            raise TickTickNotFoundError(f"Task not found: {task_id}")
+
+        task = self.tasks[task_id]
+        task.status = TaskStatus.ABANDONED
+        task.completed_time = utc_now()
+
     async def delete_task(self, task_id: str, project_id: str) -> None:
         """Mock delete task (soft delete - set deleted=1).
 


### PR DESCRIPTION
## Summary

Adds the ability to mark tasks as "Won't Do" (abandoned status).

## Changes

- Add `abandon_task()` method to `UnifiedTickTickAPI`
- Add `batch_abandon_tasks()` for batch operations  
- Add `abandon_task()` and `abandon_tasks()` to `TickTickClient`
- Add `ticktick_abandon_tasks` MCP tool to server
- Add mock `abandon_task` to test fixtures

## Usage

### SDK
```python
# Single task
await client.abandon_task(task_id="abc123", project_id="proj1")

# Batch
await client.abandon_tasks([
    ("task1", "proj1"),
    ("task2", "proj1"),
])
```

### MCP Tool
```
ticktick_abandon_tasks(tasks=[{"task_id": "abc123", "project_id": "proj1"}])
```

## Notes

- Abandoned tasks have status=-1 (distinct from completed=2 or deleted)
- Abandoned tasks appear in the "Abandoned" section in TickTick
- V2 API only (abandoned status not supported in V1)