### PR TITLE
fix: habit updates losing data due to partial API updates

### DIFF
--- a/HABIT_FIX_PR.md
+++ b/HABIT_FIX_PR.md
@@ -1,0 +1,101 @@
+# Fix: Habit updates losing data due to partial API updates
+
+## Problem
+
+Habit check-ins and updates were disappearing after being recorded. For example, checking into a habit would initially show success, but the check-in would vanish shortly after.
+
+## Root Cause
+
+TickTick's `habits/batch` API requires **full object replacement**, not partial updates. When only some fields are sent in an update request, the omitted fields are reset to their default values (null/0).
+
+This means:
+- Checking in a habit would reset other fields like `name`, `color`, `goal`, etc.
+- Archiving/unarchiving would lose check-in history
+- Any habit update would potentially corrupt other habit data
+
+## Solution
+
+Modified all habit update operations to:
+1. Fetch the complete original habit first
+2. Merge the new values with all original values
+3. Send the complete object back to the API
+
+## Changes
+
+### `src/ticktick_sdk/api/v2/client.py`
+
+- Added missing parameters to `update_habit()`:
+  - `sort_order`
+  - `target_start_date`
+  - `completed_cycles`
+  - `ex_dates`
+  - `style`
+  - `etag`
+  - `created_time`
+
+- Added new method `full_update_habit(habit_data: dict)` for sending complete habit dictionaries directly to the batch API
+
+### `src/ticktick_sdk/unified/api.py`
+
+Updated the following methods to fetch original habit and send all fields:
+
+- `update_habit()` - Now preserves all original fields when updating specific properties
+- `checkin_habit()` - Uses `full_update_habit()` with complete `Habit` object converted via `to_v2_dict()`
+- `archive_habit()` - Sends all fields with `status=2`
+- `unarchive_habit()` - Sends all fields with `status=0`
+- `batch_checkin_habits()` - Uses `full_update_habit()` for each habit update
+
+## Example
+
+Before (broken):
+```python
+# Only sends 3 fields - everything else gets reset!
+await self._v2_client.update_habit(
+    habit_id=habit_id,
+    name=original_habit.name,
+    total_checkins=calculated_total,
+    current_streak=calculated_streak,
+)
+```
+
+After (fixed):
+```python
+# Create complete habit object with all fields preserved
+updated_habit = Habit(
+    id=original_habit.id,
+    name=original_habit.name,
+    icon=original_habit.icon,
+    color=original_habit.color,
+    sort_order=original_habit.sort_order,
+    status=original_habit.status,
+    encouragement=original_habit.encouragement,
+    total_checkins=calculated_total,
+    created_time=original_habit.created_time,
+    modified_time=original_habit.modified_time,
+    archived_time=original_habit.archived_time,
+    habit_type=original_habit.habit_type,
+    goal=original_habit.goal,
+    step=original_habit.step,
+    unit=original_habit.unit,
+    etag=original_habit.etag,
+    repeat_rule=original_habit.repeat_rule,
+    reminders=original_habit.reminders,
+    record_enable=original_habit.record_enable,
+    section_id=original_habit.section_id,
+    target_days=original_habit.target_days,
+    target_start_date=original_habit.target_start_date,
+    completed_cycles=original_habit.completed_cycles,
+    ex_dates=original_habit.ex_dates,
+    current_streak=calculated_streak,
+    style=original_habit.style,
+)
+habit_data = updated_habit.to_v2_dict(for_update=True)
+await self._v2_client.full_update_habit(habit_data)
+```
+
+## Testing
+
+1. Check in to a habit
+2. Verify the check-in persists (refresh/re-fetch)
+3. Check in again and verify total increments correctly
+4. Archive and unarchive a habit, verify all data preserved

--- a/src/ticktick_sdk/api/v2/client.py
+++ b/src/ticktick_sdk/api/v2/client.py
@@ -1394,9 +1394,20 @@ class TickTickV2Client(BaseTickTickClient):
         status: int | None = None,
         total_checkins: int | None = None,
         current_streak: int | None = None,
+        # Additional fields required for full object updates
+        sort_order: int | None = None,
+        target_start_date: int | None = None,
+        completed_cycles: int | None = None,
+        ex_dates: list[str] | None = None,
+        style: int | None = None,
+        etag: str | None = None,
+        created_time: str | None = None,
     ) -> BatchResponseV2:
         """
         Update a habit.
+
+        IMPORTANT: TickTick's habits/batch API requires full object replacement,
+        not partial updates. All fields must be sent or they will be reset to defaults.
 
         Args:
             habit_id: Habit ID
@@ -1416,6 +1427,13 @@ class TickTickV2Client(BaseTickTickClient):
             status: New status (0=active, 2=archived)
             total_checkins: New total check-ins
             current_streak: New current streak
+            sort_order: Display order
+            target_start_date: Target start date (YYYYMMDD)
+            completed_cycles: Completed cycles count
+            ex_dates: Excluded dates list
+            style: Display style
+            etag: Version tag for concurrency
+            created_time: Creation timestamp (ISO format)
 
         Returns:
             Batch response
@@ -1459,8 +1477,50 @@ class TickTickV2Client(BaseTickTickClient):
             habit["totalCheckIns"] = total_checkins
         if current_streak is not None:
             habit["currentStreak"] = current_streak
+        # Additional fields for full object updates
+        if sort_order is not None:
+            habit["sortOrder"] = sort_order
+        if target_start_date is not None:
+            habit["targetStartDate"] = target_start_date
+        if completed_cycles is not None:
+            habit["completedCycles"] = completed_cycles
+        if ex_dates is not None:
+            habit["exDates"] = ex_dates
+        if style is not None:
+            habit["style"] = style
+        if etag is not None:
+            habit["etag"] = etag
 
         return await self.batch_habits(update=[habit])
+
+    async def full_update_habit(
+        self,
+        habit_data: dict[str, Any],
+    ) -> BatchResponseV2:
+        """
+        Update a habit with a complete data dictionary.
+
+        This method sends the habit data directly to the batch API without
+        filtering out None values. Use this when you need to ensure all
+        fields are included in the update.
+
+        Args:
+            habit_data: Complete habit dictionary with all required fields.
+                       Must include 'id' and should include all fields that
+                       TickTick expects (name, type, goal, etc.)
+
+        Returns:
+            Batch response
+        """
+        from datetime import datetime
+
+        # Ensure modifiedTime is set
+        if "modifiedTime" not in habit_data:
+            habit_data["modifiedTime"] = datetime.now().strftime(
+                "%Y-%m-%dT%H:%M:%S.000+0000"
+            )
+
+        return await self.batch_habits(update=[habit_data])
 
     async def delete_habit(self, habit_id: str) -> BatchResponseV2:
         """

--- a/src/ticktick_sdk/unified/api.py
+++ b/src/ticktick_sdk/unified/api.py
@@ -2357,6 +2357,10 @@ class UnifiedTickTickAPI:
 
         V2-only operation.
 
+        IMPORTANT: This method fetches the original habit first and sends
+        all fields to the API. TickTick's habits/batch API requires full
+        object replacement, not partial updates.
+
         Args:
             habit_id: Habit ID
             name: New name
@@ -2379,22 +2383,36 @@ class UnifiedTickTickAPI:
         """
         self._ensure_initialized()
 
-        # Verify habit exists
-        await self.get_habit(habit_id)  # Raises NotFoundError if missing
+        # Get original habit to preserve all fields
+        # TickTick's batch API requires full object replacement, not partial updates.
+        original_habit = await self.get_habit(habit_id)
 
+        # Merge provided values with original values
         response = await self._v2_client.update_habit(  # type: ignore
             habit_id=habit_id,
-            name=name,
-            goal=goal,
-            step=step,
-            unit=unit,
-            icon=icon,
-            color=color,
-            section_id=section_id,
-            repeat_rule=repeat_rule,
-            reminders=reminders,
-            target_days=target_days,
-            encouragement=encouragement,
+            name=name if name is not None else original_habit.name,
+            habit_type=original_habit.habit_type,
+            goal=goal if goal is not None else original_habit.goal,
+            step=step if step is not None else original_habit.step,
+            unit=unit if unit is not None else original_habit.unit,
+            icon=icon if icon is not None else original_habit.icon,
+            color=color if color is not None else original_habit.color,
+            section_id=section_id if section_id is not None else original_habit.section_id,
+            repeat_rule=repeat_rule if repeat_rule is not None else original_habit.repeat_rule,
+            reminders=reminders if reminders is not None else original_habit.reminders,
+            target_days=target_days if target_days is not None else original_habit.target_days,
+            encouragement=encouragement if encouragement is not None else original_habit.encouragement,
+            record_enable=original_habit.record_enable,
+            status=original_habit.status,
+            total_checkins=original_habit.total_checkins,
+            current_streak=original_habit.current_streak,
+            # Additional fields required for full object replacement
+            sort_order=original_habit.sort_order,
+            target_start_date=original_habit.target_start_date,
+            completed_cycles=original_habit.completed_cycles,
+            ex_dates=original_habit.ex_dates,
+            style=original_habit.style,
+            etag=original_habit.etag,
         )
 
         _check_batch_response_errors(response, "update_habit", [habit_id])
@@ -2486,12 +2504,39 @@ class UnifiedTickTickAPI:
         calculated_total = _count_total_checkins(all_checkins)
 
         # Step 4: Update habit with calculated values
-        response = await self._v2_client.update_habit(  # type: ignore
-            habit_id=habit_id,
-            name=original_habit.name,  # Preserve name!
+        # IMPORTANT: Use to_v2_dict to ensure ALL fields are included.
+        # TickTick's batch API requires full object replacement, not partial updates.
+        # Create a copy of the habit with updated counters
+        updated_habit = Habit(
+            id=original_habit.id,
+            name=original_habit.name,
+            icon=original_habit.icon,
+            color=original_habit.color,
+            sort_order=original_habit.sort_order,
+            status=original_habit.status,
+            encouragement=original_habit.encouragement,
             total_checkins=calculated_total,
+            created_time=original_habit.created_time,
+            modified_time=original_habit.modified_time,
+            archived_time=original_habit.archived_time,
+            habit_type=original_habit.habit_type,
+            goal=original_habit.goal,
+            step=original_habit.step,
+            unit=original_habit.unit,
+            etag=original_habit.etag,
+            repeat_rule=original_habit.repeat_rule,
+            reminders=original_habit.reminders,
+            record_enable=original_habit.record_enable,
+            section_id=original_habit.section_id,
+            target_days=original_habit.target_days,
+            target_start_date=original_habit.target_start_date,
+            completed_cycles=original_habit.completed_cycles,
+            ex_dates=original_habit.ex_dates,
             current_streak=calculated_streak,
+            style=original_habit.style,
         )
+        habit_data = updated_habit.to_v2_dict(for_update=True)
+        response = await self._v2_client.full_update_habit(habit_data)  # type: ignore
 
         _check_batch_response_errors(response, "checkin_habit", [habit_id])
 
@@ -2548,12 +2593,33 @@ class UnifiedTickTickAPI:
         # Get original habit data to preserve
         original_habit = await self.get_habit(habit_id)
 
-        # Use update_habit directly instead of archive_habit to preserve the name
-        # (The API nullifies fields that aren't sent in update operations)
+        # Use update_habit directly instead of archive_habit to preserve all fields
+        # TickTick's batch API requires full object replacement, not partial updates.
         response = await self._v2_client.update_habit(  # type: ignore
             habit_id=habit_id,
-            name=original_habit.name,  # Preserve name!
+            name=original_habit.name,
+            habit_type=original_habit.habit_type,
+            goal=original_habit.goal,
+            step=original_habit.step,
+            unit=original_habit.unit,
+            icon=original_habit.icon,
+            color=original_habit.color,
+            section_id=original_habit.section_id,
+            repeat_rule=original_habit.repeat_rule,
+            reminders=original_habit.reminders,
+            target_days=original_habit.target_days,
+            encouragement=original_habit.encouragement,
+            record_enable=original_habit.record_enable,
+            total_checkins=original_habit.total_checkins,
+            current_streak=original_habit.current_streak,
             status=2,  # Archived
+            # Additional fields required for full object replacement
+            sort_order=original_habit.sort_order,
+            target_start_date=original_habit.target_start_date,
+            completed_cycles=original_habit.completed_cycles,
+            ex_dates=original_habit.ex_dates,
+            style=original_habit.style,
+            etag=original_habit.etag,
         )
         _check_batch_response_errors(response, "archive_habit", [habit_id])
 
@@ -2609,12 +2675,33 @@ class UnifiedTickTickAPI:
         # Get original habit data to preserve
         original_habit = await self.get_habit(habit_id)
 
-        # Use update_habit directly instead of unarchive_habit to preserve the name
-        # (The API nullifies fields that aren't sent in update operations)
+        # Use update_habit directly instead of unarchive_habit to preserve all fields
+        # TickTick's batch API requires full object replacement, not partial updates.
         response = await self._v2_client.update_habit(  # type: ignore
             habit_id=habit_id,
-            name=original_habit.name,  # Preserve name!
+            name=original_habit.name,
+            habit_type=original_habit.habit_type,
+            goal=original_habit.goal,
+            step=original_habit.step,
+            unit=original_habit.unit,
+            icon=original_habit.icon,
+            color=original_habit.color,
+            section_id=original_habit.section_id,
+            repeat_rule=original_habit.repeat_rule,
+            reminders=original_habit.reminders,
+            target_days=original_habit.target_days,
+            encouragement=original_habit.encouragement,
+            record_enable=original_habit.record_enable,
+            total_checkins=original_habit.total_checkins,
+            current_streak=original_habit.current_streak,
             status=0,  # Active
+            # Additional fields required for full object replacement
+            sort_order=original_habit.sort_order,
+            target_start_date=original_habit.target_start_date,
+            completed_cycles=original_habit.completed_cycles,
+            ex_dates=original_habit.ex_dates,
+            style=original_habit.style,
+            etag=original_habit.etag,
         )
         _check_batch_response_errors(response, "unarchive_habit", [habit_id])
 
@@ -2762,12 +2849,37 @@ class UnifiedTickTickAPI:
             calculated_total = _count_total_checkins(all_checkins)
 
             # Update habit with calculated values
-            response = await self._v2_client.update_habit(  # type: ignore
-                habit_id=habit_id,
+            # Use full_update_habit with to_v2_dict to ensure ALL fields are sent
+            updated_habit = Habit(
+                id=original_habit.id,
                 name=original_habit.name,
+                icon=original_habit.icon,
+                color=original_habit.color,
+                sort_order=original_habit.sort_order,
+                status=original_habit.status,
+                encouragement=original_habit.encouragement,
                 total_checkins=calculated_total,
+                created_time=original_habit.created_time,
+                modified_time=original_habit.modified_time,
+                archived_time=original_habit.archived_time,
+                habit_type=original_habit.habit_type,
+                goal=original_habit.goal,
+                step=original_habit.step,
+                unit=original_habit.unit,
+                etag=original_habit.etag,
+                repeat_rule=original_habit.repeat_rule,
+                reminders=original_habit.reminders,
+                record_enable=original_habit.record_enable,
+                section_id=original_habit.section_id,
+                target_days=original_habit.target_days,
+                target_start_date=original_habit.target_start_date,
+                completed_cycles=original_habit.completed_cycles,
+                ex_dates=original_habit.ex_dates,
                 current_streak=calculated_streak,
+                style=original_habit.style,
             )
+            habit_data = updated_habit.to_v2_dict(for_update=True)
+            response = await self._v2_client.full_update_habit(habit_data)  # type: ignore
             _check_batch_response_errors(response, "batch_checkin_habits", [habit_id])
 
             # Build result habit with calculated values


### PR DESCRIPTION
## Problem

Habit check-ins and updates were disappearing after being recorded. For example, checking into a habit would initially show success, but the check-in would vanish shortly after.

## Root Cause

TickTick's `habits/batch` API requires **full object replacement**, not partial updates. When only some fields are sent in an update request, the omitted fields are reset to their default values (null/0).

This means:
- Checking in a habit would reset other fields like `name`, `color`, `goal`, etc.
- Archiving/unarchiving would lose check-in history
- Any habit update would potentially corrupt other habit data

## Solution

Modified all habit update operations to:
1. Fetch the complete original habit first
2. Merge the new values with all original values
3. Send the complete object back to the API

## Changes

### `src/ticktick_sdk/api/v2/client.py`

- Added missing parameters to `update_habit()`:
  - `sort_order`
  - `target_start_date`
  - `completed_cycles`
  - `ex_dates`
  - `style`
  - `etag`
  - `created_time`

- Added new method `full_update_habit(habit_data: dict)` for sending complete habit dictionaries directly to the batch API

### `src/ticktick_sdk/unified/api.py`

Updated the following methods to fetch original habit and send all fields:

- `update_habit()` - Now preserves all original fields when updating specific properties
- `checkin_habit()` - Uses `full_update_habit()` with complete `Habit` object converted via `to_v2_dict()`
- `archive_habit()` - Sends all fields with `status=2`
- `unarchive_habit()` - Sends all fields with `status=0`
- `batch_checkin_habits()` - Uses `full_update_habit()` for each habit update

## Testing

1. Check in to a habit
2. Verify the check-in persists (refresh/re-fetch)
3. Check in again and verify total increments correctly
4. Archive and unarchive a habit, verify all data preserved