### PR TITLE
feat: add TOTP-based 2FA support for V2 authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,15 @@ TICKTICK_USERNAME=
 TICKTICK_PASSWORD=
 
 # =============================================================================
+# 2FA / TOTP (Optional - only for 2FA-enabled accounts)
+# =============================================================================
+
+# Base32 TOTP secret for accounts with two-factor authentication enabled.
+# To get this: disable 2FA in TickTick settings, re-enable it, and copy the
+# secret key shown during setup (before scanning the QR code).
+# TICKTICK_TOTP_SECRET=
+
+# =============================================================================
 # Optional Settings
 # =============================================================================
 

--- a/src/ticktick_sdk/client/client.py
+++ b/src/ticktick_sdk/client/client.py
@@ -74,6 +74,7 @@ class TickTickClient:
         # V2 Session credentials
         username: str | None = None,
         password: str | None = None,
+        totp_secret: str | None = None,
         # General
         timeout: float = 30.0,
         device_id: str | None = None,
@@ -85,6 +86,7 @@ class TickTickClient:
             v1_access_token=v1_access_token,
             username=username,
             password=password,
+            totp_secret=totp_secret,
             timeout=timeout,
             device_id=device_id,
         )
@@ -114,6 +116,7 @@ class TickTickClient:
             v1_access_token=settings.get_v1_access_token(),
             username=settings.username,
             password=settings.get_v2_password(),
+            totp_secret=settings.get_totp_secret(),
             timeout=settings.timeout,
             device_id=settings.device_id,
         )

--- a/src/ticktick_sdk/models/task.py
+++ b/src/ticktick_sdk/models/task.py
@@ -104,6 +104,14 @@ class Task(TickTickModel):
     # Recurrence
     repeat_flag: str | None = Field(default=None, alias="repeatFlag")
     repeat_from: int | None = Field(default=None, alias="repeatFrom")
+
+    @field_validator("repeat_from", mode="before")
+    @classmethod
+    def parse_repeat_from(cls, v: Any) -> int | None:
+        """Handle empty strings from the API for repeat_from."""
+        if v == "" or v is None:
+            return None
+        return int(v)
     repeat_first_date: datetime | None = Field(default=None, alias="repeatFirstDate")
     repeat_task_id: str | None = Field(default=None, alias="repeatTaskId")
     ex_date: list[str] | None = Field(default=None, alias="exDate")

--- a/src/ticktick_sdk/server.py
+++ b/src/ticktick_sdk/server.py
@@ -66,6 +66,7 @@ V2 (Session) - Required for most operations:
     TICKTICK_PASSWORD       - TickTick account password
 
 Optional:
+    TICKTICK_TOTP_SECRET    - Base32 TOTP secret for 2FA-enabled accounts
     TICKTICK_REDIRECT_URI   - OAuth2 redirect URI (default: http://localhost:8080/callback)
     TICKTICK_TIMEOUT        - Request timeout in seconds (default: 30)
     TICKTICK_DEVICE_ID      - Device identifier (auto-generated if not set)

--- a/src/ticktick_sdk/settings.py
+++ b/src/ticktick_sdk/settings.py
@@ -53,6 +53,7 @@ class TickTickSettings(BaseSettings):
         V2 (Session):
             TICKTICK_USERNAME: Account username/email
             TICKTICK_PASSWORD: Account password
+            TICKTICK_TOTP_SECRET: TOTP secret for 2FA (base32, optional)
 
         General:
             TICKTICK_TIMEOUT: Request timeout in seconds (default: 30)
@@ -103,6 +104,10 @@ class TickTickSettings(BaseSettings):
     password: SecretStr = Field(
         default=SecretStr(""),
         description="TickTick account password",
+    )
+    totp_secret: SecretStr | None = Field(
+        default=None,
+        description="TOTP secret (base32) for 2FA-enabled accounts",
     )
 
     # =========================================================================
@@ -247,6 +252,12 @@ class TickTickSettings(BaseSettings):
     def get_v2_password(self) -> str:
         """Get the V2 password value."""
         return self.password.get_secret_value()
+
+    def get_totp_secret(self) -> str | None:
+        """Get the TOTP secret value if available."""
+        if self.totp_secret:
+            return self.totp_secret.get_secret_value()
+        return None
 
 
 # Global settings instance (lazy initialization)

--- a/src/ticktick_sdk/unified/api.py
+++ b/src/ticktick_sdk/unified/api.py
@@ -10,7 +10,12 @@ and converts between unified models and API-specific formats.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import logging
+import struct
+import time
 from datetime import date, datetime, timedelta, timezone
 from types import TracebackType
 from typing import Any, TypeVar
@@ -26,7 +31,20 @@ from ticktick_sdk.exceptions import (
     TickTickForbiddenError,
     TickTickNotFoundError,
     TickTickQuotaExceededError,
+    TickTickSessionError,
 )
+
+
+def _generate_totp(secret_b32: str) -> str:
+    """Generate a 6-digit TOTP code from a base32 secret (RFC 6238)."""
+    key = base64.b32decode(secret_b32.upper().replace(" ", ""), casefold=True)
+    counter = struct.pack(">Q", int(time.time()) // 30)
+    mac = hmac.new(key, counter, hashlib.sha1).digest()
+    offset = mac[-1] & 0x0F
+    code = struct.unpack(">I", mac[offset:offset + 4])[0] & 0x7FFFFFFF
+    return str(code % 10**6).zfill(6)
+
+
 from ticktick_sdk.models import (
     Column,
     Task,
@@ -238,6 +256,7 @@ class UnifiedTickTickAPI:
         # V2 Session credentials
         username: str | None = None,
         password: str | None = None,
+        totp_secret: str | None = None,
         # General
         timeout: float = 30.0,
         device_id: str | None = None,
@@ -253,6 +272,7 @@ class UnifiedTickTickAPI:
         self._v2_credentials = {
             "username": username,
             "password": password,
+            "totp_secret": totp_secret,
             "device_id": device_id,
             "timeout": timeout,
         }
@@ -306,10 +326,27 @@ class UnifiedTickTickAPI:
 
             # Authenticate V2 if credentials provided
             if self._v2_credentials["username"] and self._v2_credentials["password"]:
-                session = await self._v2_client.authenticate(
-                    self._v2_credentials["username"],
-                    self._v2_credentials["password"],
-                )
+                try:
+                    session = await self._v2_client.authenticate(
+                        self._v2_credentials["username"],
+                        self._v2_credentials["password"],
+                    )
+                except TickTickSessionError as e:
+                    if e.requires_2fa and e.auth_id:
+                        totp_secret = self._v2_credentials.get("totp_secret")
+                        if totp_secret:
+                            logger.info("2FA required, generating TOTP code")
+                            totp_code = _generate_totp(totp_secret)
+                            session = await self._v2_client.authenticate_2fa(
+                                e.auth_id, totp_code,
+                            )
+                        else:
+                            raise TickTickConfigurationError(
+                                "2FA required but no TOTP secret provided. "
+                                "Set TICKTICK_TOTP_SECRET to your base32 TOTP secret.",
+                            ) from e
+                    else:
+                        raise
                 self._inbox_id = session.inbox_id
                 logger.info("V2 client authenticated")
             else:


### PR DESCRIPTION
The SDK already had authenticate_2fa() implemented but the initialization flow didn't use it - when 2FA was required, it would catch the error and give up. This change completes the 2FA flow automatically using a TOTP secret provided via the TICKTICK_TOTP_SECRET environment variable.

Uses only stdlib modules (hmac, hashlib, struct) to generate TOTP codes per RFC 6238, so no new dependencies are needed.

Closes #27