### PR TITLE
Support for checklist items in tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ ticktick-sdk server --enabledModules tasks,projects
 # Enable specific tools only
 ticktick-sdk server --enabledTools ticktick_create_tasks,ticktick_list_tasks
 
-# Available modules: tasks, projects, folders, columns, tags, habits, user, focus
+# Available modules: tasks, checklist_items, projects, folders, columns, tags, habits, user, focus
 ```
 
 ### Example Conversations

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -872,6 +872,7 @@ ticktick-sdk --help       # Show help
 
 **Tool Modules** (for `--enabledModules`):
 - `tasks`: Task CRUD and management tools
+- `checklist_items`: Checklist item add/update/delete tools
 - `projects`: Project management tools
 - `folders`: Folder management tools
 - `columns`: Kanban column tools

--- a/src/ticktick_sdk/cli.py
+++ b/src/ticktick_sdk/cli.py
@@ -95,6 +95,11 @@ TOOL_MODULES = {
         "ticktick_get_statistics",
         "ticktick_get_preferences",
     ],
+    "checklist_items": [
+        "ticktick_add_checklist_items",
+        "ticktick_update_checklist_item",
+        "ticktick_delete_checklist_items",
+    ],
     "focus": [
         "ticktick_focus_heatmap",
         "ticktick_focus_by_tag",
@@ -316,7 +321,7 @@ Tool Filtering (reduces context window usage):
   Use --enabledTools or --enabledModules to load only the tools you need.
   This can significantly reduce context usage from ~30-40% to ~5-10%.
 
-Available modules: tasks, projects, folders, columns, tags, habits, user, focus
+Available modules: tasks, checklist_items, projects, folders, columns, tags, habits, user, focus
 """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -339,7 +344,7 @@ Available modules: tasks, projects, folders, columns, tags, habits, user, focus
         metavar="MODULES",
         help=(
             "Comma-separated list of tool modules to enable. "
-            "Available: tasks, projects, folders, columns, tags, habits, user, focus. "
+            "Available: tasks, checklist_items, projects, folders, columns, tags, habits, user, focus. "
             "Example: --enabledModules tasks,projects"
         ),
     )

--- a/src/ticktick_sdk/client/client.py
+++ b/src/ticktick_sdk/client/client.py
@@ -219,6 +219,7 @@ class TickTickClient:
         recurrence: str | None = None,
         tags: list[str] | None = None,
         parent_id: str | None = None,
+        items: list[str] | None = None,
     ) -> Task:
         """
         Create a new task.
@@ -237,6 +238,7 @@ class TickTickClient:
             recurrence: Recurrence rule (RRULE format)
             tags: List of tag names
             parent_id: Parent task ID (for subtasks)
+            items: Checklist item titles (auto-sets kind to CHECKLIST)
 
         Returns:
             Created task
@@ -260,6 +262,7 @@ class TickTickClient:
             repeat_flag=recurrence,
             tags=tags,
             parent_id=parent_id,
+            items=items,
         )
 
     async def update_task(self, task: Task) -> Task:

--- a/src/ticktick_sdk/client/client.py
+++ b/src/ticktick_sdk/client/client.py
@@ -297,6 +297,126 @@ class TickTickClient:
         """
         await self._api.delete_task(task_id, project_id)
 
+    # =========================================================================
+    # Checklist Item Operations
+    # =========================================================================
+
+    async def add_checklist_items(
+        self,
+        task_id: str,
+        project_id: str,
+        items: list[str],
+    ) -> Task:
+        """
+        Add checklist items to a task.
+
+        Fetches the task, appends new items, and updates. Auto-sets
+        kind to CHECKLIST if not already set.
+
+        Args:
+            task_id: Task ID
+            project_id: Project ID
+            items: List of checklist item titles to add
+
+        Returns:
+            Updated task with new items
+        """
+        from ticktick_sdk.models.task import ChecklistItem
+        from ticktick_sdk.settings import _generate_object_id
+
+        task = await self.get_task(task_id, project_id)
+
+        if task.kind != "CHECKLIST":
+            task.kind = "CHECKLIST"
+
+        start_order = len(task.items)
+        for i, title in enumerate(items):
+            task.items.append(ChecklistItem(
+                id=_generate_object_id(),
+                title=title,
+                status=0,
+                sort_order=start_order + i,
+            ))
+
+        return await self.update_task(task)
+
+    async def update_checklist_item(
+        self,
+        task_id: str,
+        project_id: str,
+        item_id: str,
+        *,
+        title: str | None = None,
+        is_completed: bool | None = None,
+    ) -> Task:
+        """
+        Update a single checklist item on a task.
+
+        Args:
+            task_id: Task ID
+            project_id: Project ID
+            item_id: Checklist item ID to update
+            title: New title (if changing)
+            is_completed: Set completion status (if changing)
+
+        Returns:
+            Updated task
+
+        Raises:
+            TickTickNotFoundError: If item_id not found on the task
+        """
+        from ticktick_sdk.exceptions import TickTickNotFoundError
+
+        task = await self.get_task(task_id, project_id)
+
+        item = next((i for i in task.items if i.id == item_id), None)
+        if item is None:
+            raise TickTickNotFoundError(
+                f"Checklist item '{item_id}' not found on task '{task_id}'"
+            )
+
+        if title is not None:
+            item.title = title
+        if is_completed is not None:
+            item.status = 1 if is_completed else 0
+
+        return await self.update_task(task)
+
+    async def delete_checklist_items(
+        self,
+        task_id: str,
+        project_id: str,
+        item_ids: list[str],
+    ) -> Task:
+        """
+        Delete checklist items from a task.
+
+        Args:
+            task_id: Task ID
+            project_id: Project ID
+            item_ids: List of checklist item IDs to remove
+
+        Returns:
+            Updated task with items removed
+
+        Raises:
+            TickTickNotFoundError: If any item_id not found on the task
+        """
+        from ticktick_sdk.exceptions import TickTickNotFoundError
+
+        task = await self.get_task(task_id, project_id)
+
+        ids_to_remove = set(item_ids)
+        existing_ids = {i.id for i in task.items}
+        missing = ids_to_remove - existing_ids
+        if missing:
+            raise TickTickNotFoundError(
+                f"Checklist item(s) not found on task '{task_id}': {', '.join(missing)}"
+            )
+
+        task.items = [i for i in task.items if i.id not in ids_to_remove]
+        return await self.update_task(task)
+
     async def get_completed_tasks(
         self,
         days: int = 7,

--- a/src/ticktick_sdk/server.py
+++ b/src/ticktick_sdk/server.py
@@ -434,6 +434,7 @@ async def ticktick_create_tasks(params: CreateTasksInput, ctx: Context) -> str:
                 - description (str): Checklist description (for CHECKLIST kind)
                 - kind (str): Task type - 'TEXT' (standard task, default), 'NOTE' (note),
                   or 'CHECKLIST' (checklist with subtask items)
+                - items (list[str]): Checklist item titles (auto-sets kind to 'CHECKLIST')
                 - priority (str): 'none', 'low', 'medium', 'high'
                 - start_date (str): Start date in ISO format (REQUIRED for recurrence)
                 - due_date (str): Due date in ISO format
@@ -459,8 +460,8 @@ async def ticktick_create_tasks(params: CreateTasksInput, ctx: Context) -> str:
         Note task (different from standard task):
             tasks=[{"title": "Meeting notes", "kind": "NOTE", "content": "Discussion points..."}]
 
-        Checklist task:
-            tasks=[{"title": "Packing list", "kind": "CHECKLIST"}]
+        Checklist task with items:
+            tasks=[{"title": "Packing list", "kind": "CHECKLIST", "items": ["Clothes", "Toiletries", "Charger"]}]
 
         Recurring task (requires start_date):
             tasks=[{"title": "Daily standup", "start_date": "2026-01-20", "recurrence": "RRULE:FREQ=DAILY"}]
@@ -502,6 +503,8 @@ async def ticktick_create_tasks(params: CreateTasksInput, ctx: Context) -> str:
                 spec["parent_id"] = task_item.parent_id
             if task_item.kind:
                 spec["kind"] = task_item.kind
+            if task_item.items:
+                spec["items"] = task_item.items
 
             task_specs.append(spec)
 

--- a/src/ticktick_sdk/server.py
+++ b/src/ticktick_sdk/server.py
@@ -12,6 +12,7 @@ Task Management:
     - Create tasks with titles, due dates, priorities, tags, reminders, and recurrence
     - Create subtasks (parent-child relationships)
     - Update, complete, delete, and move tasks between projects
+    - Add, update, and delete checklist items on CHECKLIST tasks
     - List active, completed, and overdue tasks
     - Search tasks by title or content
 
@@ -110,6 +111,10 @@ from ticktick_sdk.tools.inputs import (
     UpdateTasksInput,
     CompleteTasksInput,
     DeleteTasksInput,
+    # Checklist item inputs
+    AddChecklistItemsInput,
+    UpdateChecklistItemInput,
+    DeleteChecklistItemsInput,
     MoveTasksInput,
     SetTaskParentsInput,
     UnparentTasksInput,
@@ -717,6 +722,9 @@ async def ticktick_update_tasks(params: UpdateTasksInput, ctx: Context) -> str:
                 - recurrence (str): RRULE format for recurring tasks
                 - column_id (str): Kanban column ID for board assignment
                   (use empty string '' to remove from column)
+                - items (list[str]): Replace ALL checklist items (auto-sets kind to 'CHECKLIST').
+                  Use empty list [] to clear all items.
+                  For individual item operations, use the dedicated checklist item tools.
             - response_format (str): 'markdown' (default) or 'json'
 
     Returns:
@@ -725,6 +733,9 @@ async def ticktick_update_tasks(params: UpdateTasksInput, ctx: Context) -> str:
     Examples:
         Update priority:
             tasks=[{"task_id": "abc123", "project_id": "proj1", "priority": "high"}]
+
+        Replace all checklist items:
+            tasks=[{"task_id": "abc123", "project_id": "proj1", "items": ["Step 1", "Step 2", "Step 3"]}]
 
         Convert task to note:
             tasks=[{"task_id": "abc123", "project_id": "proj1", "kind": "NOTE"}]
@@ -774,6 +785,8 @@ async def ticktick_update_tasks(params: UpdateTasksInput, ctx: Context) -> str:
                 spec["column_id"] = task_item.column_id
             if task_item.kind is not None:
                 spec["kind"] = task_item.kind
+            if task_item.items is not None:
+                spec["items"] = task_item.items
 
             update_specs.append(spec)
 
@@ -794,6 +807,171 @@ async def ticktick_update_tasks(params: UpdateTasksInput, ctx: Context) -> str:
 
     except Exception as e:
         return handle_error(e, "update_tasks")
+
+
+# =============================================================================
+# Checklist Item Tools
+# =============================================================================
+
+
+@mcp.tool(
+    name="ticktick_add_checklist_items",
+    annotations={
+        "title": "Add Checklist Items",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def ticktick_add_checklist_items(params: AddChecklistItemsInput, ctx: Context) -> str:
+    """
+    Add checklist items to an existing task.
+
+    Appends new checklist items to a task. If the task is not already a CHECKLIST
+    type, it will be converted to one automatically.
+
+    Args:
+        params: Parameters:
+            - task_id (str, required): Task ID to add items to
+            - project_id (str, required): Project ID the task belongs to
+            - items (list[str], required): Checklist item titles to add
+            - response_format (str): 'markdown' (default) or 'json'
+
+    Returns:
+        Updated task with new checklist items
+
+    Examples:
+        Add items to a checklist:
+            task_id="abc123...", project_id="proj123...", items=["Buy milk", "Buy eggs"]
+    """
+    try:
+        client = get_client(ctx)
+        task = await client.add_checklist_items(
+            task_id=params.task_id,
+            project_id=params.project_id,
+            items=params.items,
+        )
+
+        if params.response_format == ResponseFormat.MARKDOWN:
+            return f"# Checklist Items Added\n\n{format_task_markdown(task)}"
+        else:
+            return json.dumps({
+                "success": True,
+                "items_added": len(params.items),
+                "task": format_task_json(task),
+            }, indent=2)
+
+    except Exception as e:
+        return handle_error(e, "add_checklist_items")
+
+
+@mcp.tool(
+    name="ticktick_update_checklist_item",
+    annotations={
+        "title": "Update Checklist Item",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def ticktick_update_checklist_item(params: UpdateChecklistItemInput, ctx: Context) -> str:
+    """
+    Update a single checklist item on a task.
+
+    Use ticktick_get_task first to see checklist item IDs, then update by ID.
+
+    Args:
+        params: Parameters:
+            - task_id (str, required): Task ID containing the item
+            - project_id (str, required): Project ID the task belongs to
+            - item_id (str, required): Checklist item ID to update
+            - title (str, optional): New title for the item
+            - is_completed (bool, optional): true to complete, false to uncomplete
+            - response_format (str): 'markdown' (default) or 'json'
+
+    Returns:
+        Updated task
+
+    Examples:
+        Complete a checklist item:
+            task_id="abc123...", project_id="proj123...", item_id="item456...", is_completed=true
+
+        Rename a checklist item:
+            task_id="abc123...", project_id="proj123...", item_id="item456...", title="New title"
+    """
+    try:
+        client = get_client(ctx)
+        task = await client.update_checklist_item(
+            task_id=params.task_id,
+            project_id=params.project_id,
+            item_id=params.item_id,
+            title=params.title,
+            is_completed=params.is_completed,
+        )
+
+        if params.response_format == ResponseFormat.MARKDOWN:
+            return f"# Checklist Item Updated\n\n{format_task_markdown(task)}"
+        else:
+            return json.dumps({
+                "success": True,
+                "task": format_task_json(task),
+            }, indent=2)
+
+    except Exception as e:
+        return handle_error(e, "update_checklist_item")
+
+
+@mcp.tool(
+    name="ticktick_delete_checklist_items",
+    annotations={
+        "title": "Delete Checklist Items",
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def ticktick_delete_checklist_items(params: DeleteChecklistItemsInput, ctx: Context) -> str:
+    """
+    Delete checklist items from a task.
+
+    Use ticktick_get_task first to see checklist item IDs, then delete by ID.
+
+    Args:
+        params: Parameters:
+            - task_id (str, required): Task ID to remove items from
+            - project_id (str, required): Project ID the task belongs to
+            - item_ids (list[str], required): Checklist item IDs to delete
+            - response_format (str): 'markdown' (default) or 'json'
+
+    Returns:
+        Updated task with items removed
+
+    Examples:
+        Delete items:
+            task_id="abc123...", project_id="proj123...", item_ids=["item1", "item2"]
+    """
+    try:
+        client = get_client(ctx)
+        task = await client.delete_checklist_items(
+            task_id=params.task_id,
+            project_id=params.project_id,
+            item_ids=params.item_ids,
+        )
+
+        if params.response_format == ResponseFormat.MARKDOWN:
+            return f"# Checklist Items Deleted\n\n{format_task_markdown(task)}"
+        else:
+            return json.dumps({
+                "success": True,
+                "items_deleted": len(params.item_ids),
+                "task": format_task_json(task),
+            }, indent=2)
+
+    except Exception as e:
+        return handle_error(e, "delete_checklist_items")
 
 
 @mcp.tool(

--- a/src/ticktick_sdk/tools/inputs.py
+++ b/src/ticktick_sdk/tools/inputs.py
@@ -120,6 +120,15 @@ class TaskCreateItem(BaseModel):
         ),
         pattern=r"^(TEXT|NOTE|CHECKLIST)$",
     )
+    items: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Checklist item titles. Only used when kind='CHECKLIST'. "
+            "Each string becomes a checklist item. "
+            "Example: ['Buy milk', 'Buy eggs', 'Buy bread']"
+        ),
+        max_length=100,
+    )
 
     @field_validator("priority")
     @classmethod
@@ -127,6 +136,15 @@ class TaskCreateItem(BaseModel):
         if v is None:
             return None
         return v.lower()
+
+    @field_validator("items")
+    @classmethod
+    def validate_items(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is not None:
+            for item in v:
+                if not item.strip():
+                    raise ValueError("Checklist item titles must not be empty")
+        return v
 
 
 class CreateTasksInput(BaseMCPInput):

--- a/src/ticktick_sdk/tools/inputs.py
+++ b/src/ticktick_sdk/tools/inputs.py
@@ -231,6 +231,24 @@ class TaskUpdateItem(BaseModel):
         ),
         pattern=r"^(TEXT|NOTE|CHECKLIST)$",
     )
+    items: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Replace ALL checklist items with this list. Auto-sets kind to 'CHECKLIST'. "
+            "Use an empty list to clear all items. "
+            "For adding/updating/deleting individual items, use the dedicated checklist item tools instead."
+        ),
+        max_length=100,
+    )
+
+    @field_validator("items")
+    @classmethod
+    def validate_items(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is not None:
+            for item in v:
+                if not item.strip():
+                    raise ValueError("Checklist item titles must not be empty")
+        return v
 
 
 class UpdateTasksInput(BaseMCPInput):
@@ -245,6 +263,102 @@ class UpdateTasksInput(BaseMCPInput):
     response_format: ResponseFormat = Field(
         default=ResponseFormat.MARKDOWN,
         description="Output format",
+    )
+
+
+# =============================================================================
+# Checklist Item Input Models
+# =============================================================================
+
+
+class AddChecklistItemsInput(BaseMCPInput):
+    """Add checklist items to an existing task."""
+
+    task_id: str = Field(
+        ...,
+        description="Task ID to add checklist items to",
+        pattern=r"^[a-f0-9]{24}$",
+    )
+    project_id: str = Field(
+        ...,
+        description="Project ID the task belongs to",
+        pattern=r"^(inbox\d+|[a-f0-9]{24})$",
+    )
+    items: List[str] = Field(
+        ...,
+        description="Checklist item titles to add (e.g., ['Buy milk', 'Buy eggs'])",
+        min_length=1,
+        max_length=100,
+    )
+    response_format: ResponseFormat = Field(
+        default=ResponseFormat.MARKDOWN,
+        description="Output format: 'markdown' or 'json'",
+    )
+
+    @field_validator("items")
+    @classmethod
+    def validate_items(cls, v: List[str]) -> List[str]:
+        for item in v:
+            if not item.strip():
+                raise ValueError("Checklist item titles must not be empty")
+        return v
+
+
+class UpdateChecklistItemInput(BaseMCPInput):
+    """Update a single checklist item on a task."""
+
+    task_id: str = Field(
+        ...,
+        description="Task ID containing the checklist item",
+        pattern=r"^[a-f0-9]{24}$",
+    )
+    project_id: str = Field(
+        ...,
+        description="Project ID the task belongs to",
+        pattern=r"^(inbox\d+|[a-f0-9]{24})$",
+    )
+    item_id: str = Field(
+        ...,
+        description="Checklist item ID to update",
+    )
+    title: Optional[str] = Field(
+        default=None,
+        description="New title for the checklist item",
+        min_length=1,
+        max_length=500,
+    )
+    is_completed: Optional[bool] = Field(
+        default=None,
+        description="Set to true to mark complete, false to mark incomplete",
+    )
+    response_format: ResponseFormat = Field(
+        default=ResponseFormat.MARKDOWN,
+        description="Output format: 'markdown' or 'json'",
+    )
+
+
+class DeleteChecklistItemsInput(BaseMCPInput):
+    """Delete checklist items from a task."""
+
+    task_id: str = Field(
+        ...,
+        description="Task ID to delete checklist items from",
+        pattern=r"^[a-f0-9]{24}$",
+    )
+    project_id: str = Field(
+        ...,
+        description="Project ID the task belongs to",
+        pattern=r"^(inbox\d+|[a-f0-9]{24})$",
+    )
+    item_ids: List[str] = Field(
+        ...,
+        description="List of checklist item IDs to delete",
+        min_length=1,
+        max_length=100,
+    )
+    response_format: ResponseFormat = Field(
+        default=ResponseFormat.MARKDOWN,
+        description="Output format: 'markdown' or 'json'",
     )
 
 

--- a/src/ticktick_sdk/unified/api.py
+++ b/src/ticktick_sdk/unified/api.py
@@ -448,6 +448,36 @@ class UnifiedTickTickAPI:
             operation="get_task",
         )
 
+    @staticmethod
+    def _normalize_checklist_items(
+        items: list[dict[str, Any]] | list[str] | None,
+    ) -> list[dict[str, Any]] | None:
+        """Normalize checklist items to V2 API format.
+
+        Accepts either a list of title strings or a list of dicts.
+        Generates IDs and defaults for items that need them.
+        """
+        if not items:
+            return None
+        result = []
+        for i, item in enumerate(items):
+            if isinstance(item, str):
+                result.append({
+                    "id": _generate_object_id(),
+                    "title": item,
+                    "status": 0,
+                    "sortOrder": i,
+                })
+            elif isinstance(item, dict):
+                if "id" not in item:
+                    item["id"] = _generate_object_id()
+                if "status" not in item:
+                    item["status"] = 0
+                if "sortOrder" not in item:
+                    item["sortOrder"] = i
+                result.append(item)
+        return result or None
+
     async def create_task(
         self,
         title: str,
@@ -465,6 +495,7 @@ class UnifiedTickTickAPI:
         repeat_flag: str | None = None,
         tags: list[str] | None = None,
         parent_id: str | None = None,
+        items: list[dict[str, Any]] | list[str] | None = None,
     ) -> Task:
         """
         Create a new task.
@@ -486,6 +517,7 @@ class UnifiedTickTickAPI:
             repeat_flag: Recurrence rule
             tags: List of tags (V2 only)
             parent_id: Parent task ID for subtasks (V2 only)
+            items: Checklist items (list of title strings or dicts)
 
         Returns:
             Created task
@@ -513,6 +545,11 @@ class UnifiedTickTickAPI:
         start_str = Task.format_datetime(start_date, "v2") if start_date else None
         due_str = Task.format_datetime(due_date, "v2") if due_date else None
 
+        # Normalize checklist items and auto-set kind
+        normalized_items = self._normalize_checklist_items(items)
+        if normalized_items and kind is None:
+            kind = "CHECKLIST"
+
         # V2 is REQUIRED (not optional fallback)
         if not self._router.has_v2:
             raise TickTickAPIUnavailableError(
@@ -534,6 +571,7 @@ class UnifiedTickTickAPI:
             reminders=[{"trigger": r} for r in reminders] if reminders else None,
             repeat_flag=repeat_flag,
             tags=tags,
+            items=normalized_items,
             # Note: parent_id is NOT passed here - V2 API ignores it during creation
             # We set it separately below via set_task_parent
         )
@@ -997,13 +1035,19 @@ class UnifiedTickTickAPI:
                 if isinstance(priority, str):
                     priority = int(priority)
 
+            # Normalize checklist items and auto-set kind
+            normalized_items = self._normalize_checklist_items(task_spec.get("items"))
+            kind = task_spec.get("kind")
+            if normalized_items and kind is None:
+                kind = "CHECKLIST"
+
             # Create the task
             response = await self._v2_client.create_task(  # type: ignore
                 title=title,
                 project_id=project_id,
                 content=task_spec.get("content"),
                 desc=task_spec.get("description"),
-                kind=task_spec.get("kind"),
+                kind=kind,
                 priority=priority,
                 start_date=start_date,
                 due_date=due_date,
@@ -1012,6 +1056,7 @@ class UnifiedTickTickAPI:
                 reminders=reminders,
                 repeat_flag=task_spec.get("recurrence"),
                 tags=task_spec.get("tags"),
+                items=normalized_items,
             )
 
             # Get the created task ID

--- a/src/ticktick_sdk/unified/api.py
+++ b/src/ticktick_sdk/unified/api.py
@@ -1167,6 +1167,18 @@ class UnifiedTickTickAPI:
                 v2_update["columnId"] = update["column_id"] if update["column_id"] else ""
             if "kind" in update and update["kind"] is not None:
                 v2_update["kind"] = update["kind"]
+            if "items" in update:
+                raw_items = update["items"]
+                if raw_items is not None:
+                    normalized = self._normalize_checklist_items(raw_items)
+                    if normalized:
+                        v2_update["items"] = normalized
+                        if "kind" not in v2_update:
+                            v2_update["kind"] = "CHECKLIST"
+                    else:
+                        v2_update["items"] = []
+                else:
+                    v2_update["items"] = []
 
             v2_updates.append(v2_update)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -643,6 +643,29 @@ class MockUnifiedAPI:
         # Filter out None values to allow factory defaults to apply
         filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
+        # Convert raw items (strings/dicts) to ChecklistItem objects for TaskFactory
+        if "items" in filtered_kwargs:
+            raw_items = filtered_kwargs["items"]
+            checklist_items = []
+            for i, item in enumerate(raw_items):
+                if isinstance(item, str):
+                    checklist_items.append(ChecklistItem(
+                        id=IDGenerator.task_id(),
+                        title=item,
+                        status=0,
+                        sort_order=i,
+                    ))
+                elif isinstance(item, dict):
+                    checklist_items.append(ChecklistItem(
+                        id=item.get("id", IDGenerator.task_id()),
+                        title=item.get("title"),
+                        status=item.get("status", 0),
+                        sort_order=item.get("sortOrder", i),
+                    ))
+                elif isinstance(item, ChecklistItem):
+                    checklist_items.append(item)
+            filtered_kwargs["items"] = checklist_items
+
         task = TaskFactory.create(
             title=title,
             project_id=project_id or self.inbox_id,

--- a/tests/test_client_tasks.py
+++ b/tests/test_client_tasks.py
@@ -241,6 +241,32 @@ class TestTaskCreation:
         assert task.priority == TaskPriority.HIGH
         assert set(task.tags) == {"comprehensive", "test"}
 
+    async def test_create_task_with_checklist_items(self, client: TickTickClient):
+        """Test creating a checklist task with items."""
+        task = await client.create_task(
+            title="Shopping List",
+            items=["Buy milk", "Buy eggs", "Buy bread"],
+        )
+
+        assert task.title == "Shopping List"
+        assert len(task.items) == 3
+        assert task.items[0].title == "Buy milk"
+        assert task.items[1].title == "Buy eggs"
+        assert task.items[2].title == "Buy bread"
+
+    async def test_create_task_items_auto_sets_kind(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test that providing items auto-sets kind to CHECKLIST."""
+        task = await client.create_task(
+            title="Checklist",
+            items=["Item 1", "Item 2"],
+        )
+
+        # Verify items were passed to the unified API
+        calls = mock_api.get_calls("create_task")
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs.get("items") == ["Item 1", "Item 2"]
+
     async def test_quick_add(self, client: TickTickClient):
         """Test quick_add convenience method."""
         task = await client.quick_add("Quick task text")

--- a/tests/test_client_tasks.py
+++ b/tests/test_client_tasks.py
@@ -282,6 +282,115 @@ class TestTaskCreation:
 
 
 # =============================================================================
+# Checklist Item Tests
+# =============================================================================
+
+
+class TestChecklistItems:
+    """Tests for checklist item add/update/delete operations."""
+
+    async def test_add_checklist_items(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test adding checklist items to a task."""
+        task = await client.create_task(title="My Checklist", items=["Item 1"])
+
+        updated = await client.add_checklist_items(
+            task_id=task.id,
+            project_id=task.project_id,
+            items=["Item 2", "Item 3"],
+        )
+
+        assert len(updated.items) == 3
+        assert updated.items[1].title == "Item 2"
+        assert updated.items[2].title == "Item 3"
+
+    async def test_add_checklist_items_sets_kind(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test that adding items to a non-checklist task sets kind to CHECKLIST."""
+        task = await client.create_task(title="Plain Task")
+        assert task.kind != "CHECKLIST"
+
+        updated = await client.add_checklist_items(
+            task_id=task.id,
+            project_id=task.project_id,
+            items=["New item"],
+        )
+
+        assert updated.kind == "CHECKLIST"
+        assert len(updated.items) == 1
+
+    async def test_update_checklist_item_title(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test updating a checklist item's title."""
+        task = await client.create_task(title="Checklist", items=["Original"])
+        item_id = task.items[0].id
+
+        updated = await client.update_checklist_item(
+            task_id=task.id,
+            project_id=task.project_id,
+            item_id=item_id,
+            title="Renamed",
+        )
+
+        assert updated.items[0].title == "Renamed"
+
+    async def test_update_checklist_item_complete(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test completing a checklist item."""
+        task = await client.create_task(title="Checklist", items=["Do this"])
+        item_id = task.items[0].id
+
+        updated = await client.update_checklist_item(
+            task_id=task.id,
+            project_id=task.project_id,
+            item_id=item_id,
+            is_completed=True,
+        )
+
+        assert updated.items[0].is_completed is True
+
+    async def test_update_checklist_item_not_found(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test updating a nonexistent checklist item raises error."""
+        from ticktick_sdk.exceptions import TickTickNotFoundError
+
+        task = await client.create_task(title="Checklist", items=["Item"])
+
+        with pytest.raises(TickTickNotFoundError):
+            await client.update_checklist_item(
+                task_id=task.id,
+                project_id=task.project_id,
+                item_id="nonexistent_id",
+                title="New title",
+            )
+
+    async def test_delete_checklist_items(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test deleting checklist items."""
+        task = await client.create_task(
+            title="Checklist",
+            items=["Keep", "Remove 1", "Remove 2"],
+        )
+        remove_ids = [task.items[1].id, task.items[2].id]
+
+        updated = await client.delete_checklist_items(
+            task_id=task.id,
+            project_id=task.project_id,
+            item_ids=remove_ids,
+        )
+
+        assert len(updated.items) == 1
+        assert updated.items[0].title == "Keep"
+
+    async def test_delete_checklist_items_not_found(self, client: TickTickClient, mock_api: MockUnifiedAPI):
+        """Test deleting nonexistent checklist items raises error."""
+        from ticktick_sdk.exceptions import TickTickNotFoundError
+
+        task = await client.create_task(title="Checklist", items=["Item"])
+
+        with pytest.raises(TickTickNotFoundError):
+            await client.delete_checklist_items(
+                task_id=task.id,
+                project_id=task.project_id,
+                item_ids=["nonexistent_id"],
+            )
+
+
+# =============================================================================
 # Task Retrieval Tests
 # =============================================================================
 


### PR DESCRIPTION
### Summary

  - Add `items` parameter to task creation across all layers (MCP server, high-level client, unified API) so CHECKLIST tasks can be created with checklist items in one step
  - Add three new MCP tools for managing individual checklist items: `ticktick_add_checklist_items`, `ticktick_update_checklist_item`, `ticktick_delete_checklist_items`
  - Support full items list replacement via `ticktick_update_tasks` for bulk redeclaration
  - Register `checklist_items` as a CLI tool module for `--enabledModules` filtering

### Test plan (completed)

  - Verify all 9 new unit tests pass (TestChecklistItems class + 2 creation tests)
  - Verify no regressions in existing test suite
  - Manual test: create a CHECKLIST task with items via MCP, verify items appear in TickTick
  - Manual test: add/update/delete individual checklist items via MCP tools
  - Manual test: replace full items list via ticktick_update_tasks
  - Verify --enabledModules checklist_items loads only the 3 checklist item tools